### PR TITLE
Support both abstract sockets and sockets based on filesystem paths.

### DIFF
--- a/memcr.h
+++ b/memcr.h
@@ -30,7 +30,7 @@
 #endif
 
 struct parasite_args {
-	char addr[32]; /* abstract socket address */
+	char addr[108]; /* abstract or filesystem socket address */
 };
 
 typedef enum {
@@ -66,3 +66,4 @@ struct vm_page {
 } __attribute__((packed));
 
 #endif
+

--- a/parasite.c
+++ b/parasite.c
@@ -376,7 +376,8 @@ void __attribute__((__used__)) service(unsigned int cmd, void *args)
 
 	addr.sun_family = PF_UNIX;
 	xstrcpy(addr.sun_path, pa->addr);
-	addr.sun_path[0] = '\0';
+	if ('#' == addr.sun_path[0])
+		addr.sun_path[0] = '\0';
 
 	ret = sys_bind(srvd, (struct sockaddr *)&addr, sizeof(addr));
 	if (ret) {
@@ -401,3 +402,4 @@ void __attribute__((__used__)) service(unsigned int cmd, void *args)
 	sys_close(srvd);
 	sys_exit(0);
 }
+


### PR DESCRIPTION
Introduced new variable - socket_dir and new, optional parameter to memcr: --parasite-socket-dir.
In case of parameter --parasite-socket-dir is specified, a socket is created under the given directory. Socket file has to be removed after restore to make checkpoint/restore available again. Sockets' names creation is unified in dedicated functions to concatenate strings once in the source code for each case. Existing 'dir' variables renamed to avoid confusion.