### PR TITLE
arm: make asm code more generic + other fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ else
     $(error unsupported arch "$(ARCH)")
 endif
 
-PCFLAGS = -Wstrict-prototypes -fno-stack-protector -fpie -nostdlib -fomit-frame-pointer -Wa,--noexecstack
+PCFLAGS = -Wstrict-prototypes -fno-stack-protector -fpie -nostdlib -ffreestanding -fomit-frame-pointer -Wa,--noexecstack
 
 GOFF = ./gen-offsets.sh
 

--- a/arch/arm/cpu.c
+++ b/arch/arm/cpu.c
@@ -24,9 +24,9 @@
 void set_cpu_regs(struct user_regs_struct *uregs, unsigned long *pc, unsigned long arg0, unsigned long arg1)
 {
 	uregs->orig_r0 = -1;			/* avoid end-of-syscall processing */
-	uregs->pc = (unsigned long )pc;	/* point to the injected blob */
-	uregs->r8 = arg0;				/* r8 used as arg0 to blob */
-	uregs->r9 = arg1;				/* r9 used as arg1 to blob */
+	uregs->pc = (unsigned long )pc;		/* point to the injected blob */
+	uregs->r8 = arg0;			/* r8 used as arg0 to blob */
+	uregs->r9 = arg1;			/* r9 used as arg1 to blob */
 
 	/* Make sure flags are in known state */
 	uregs->cpsr &= PSR_f | PSR_s | PSR_x | MODE32_BIT;

--- a/arch/arm/enter.c
+++ b/arch/arm/enter.c
@@ -86,8 +86,7 @@ static void __attribute__((used)) container(void)
 		".global clone_blob				\n"
 		"clone_blob:					\n"
 		"mov r7, #120					\n" /* __NR_clone */
-		"movw r0, #0x2f00				\n" /* r0 = (CLONE_FILES | CLONE_FS | CLONE_IO | CLONE_SIGHAND | CLONE_SYSVSEM | CLONE_THREAD | CLONE_VM | CLONE_PTRACE) */
-		"movt r0, #0x8005				\n"
+		"ldr r0, CLONE_FLAGS				\n"
 		"mov r1, #0					\n" /* @newsp */
 		"mov r2, #0					\n" /* @parent_tid */
 		"mov r3, #0					\n" /* @child_tid */
@@ -95,6 +94,8 @@ static void __attribute__((used)) container(void)
 		"cmp r0, #0					\n"
 		"bxeq r8					\n" /* bx parasite */
 		"udf #16					\n" /* SIGTRAP */
+		"CLONE_FLAGS:					\n"
+		".word 0x80052f00				\n" /* (CLONE_FILES | CLONE_FS | CLONE_IO | CLONE_SIGHAND | CLONE_SYSVSEM | CLONE_THREAD | CLONE_VM | CLONE_PTRACE) */
 		".global clone_blob_size			\n"
 		"clone_blob_size:				\n"
 		".int clone_blob_size - clone_blob		\n"

--- a/arch/arm/parasite-head.S
+++ b/arch/arm/parasite-head.S
@@ -23,13 +23,13 @@
 	.globl __parasite_head_start
 	.align 4, 0x00
 
-_parasite_head_start:
-	adr %sp, __parasite_stack
-	adr %r0, __parasite_cmd
-	ldr %r0, [%r0]
-	adr %r1, __parasite_args
+__parasite_head_start:
+	adr sp, __parasite_stack
+	adr r0, __parasite_cmd
+	ldr r0, [r0]
+	adr r1, __parasite_args
 	bl service
-	.byte 0xf0, 0x01, 0xf0, 0xe7 @ UDF #16 / SIGTRAP
+	udf #16 @ SIGTRAP
 	.align 4, 0x00
 
 __parasite_cmd:


### PR DESCRIPTION
This fixes compilation for Raspberry Pi Zero W target where movw and movt are not supported.

Assembler messages:
Error: selected processor does not support `movw r0,#0x2f00' in ARM mode
Error: selected processor does not support `movt r0,#0x8005' in ARM mode

Add -ffreestanding so that gcc doesn't insert a call to memcpy/memset in parasite code.