### PR TITLE
Checkpont / restore procedures are synchronous now.

### DIFF
--- a/memcr.h
+++ b/memcr.h
@@ -52,6 +52,15 @@ struct service_command {
 	pid_t pid;
 } __attribute__((packed));
 
+typedef enum {
+	MEMCR_OK = 0,
+	MEMCR_ERROR = -1
+} memcr_svc_response;
+
+struct service_response {
+	memcr_svc_response resp_code;
+} __attribute__((packed));
+
 struct vm_skip_addr {
 	void *addr;
 	char desc;


### PR DESCRIPTION
Service response introduced with OK or ERROR statuses. It is sent to client after checkpoint and after restore phase separately. Memcr can still handle only one PID at a time and expects strict parameters.