### PR TITLE
Fix sigset handling

### DIFF
--- a/arch/arm/enter.c
+++ b/arch/arm/enter.c
@@ -49,11 +49,9 @@ static void __attribute__((used)) container(void)
 		"mov r7, #175					\n" /* __NR_rt_sigprocmask */
 		"mov r0, %0					\n" /* @how */
 		"mov r1, r8					\n" /* @nset */
-		"add r2, r8, #8					\n" /* @oset */
-		"mov r9, r2					\n"
+		"mov r2, r8					\n" /* @oset */
 		"mov r3, #8					\n" /* @sigsetsize */
 		"svc 0x0					\n"
-		"ldr r8, [r9]					\n"
 		"udf #16					\n" /* SIGTRAP */
 		".global sigprocmask_blob_size			\n"
 		"sigprocmask_blob_size:				\n"

--- a/arch/arm64/enter.c
+++ b/arch/arm64/enter.c
@@ -50,11 +50,9 @@ static void __attribute__((used)) container(void)
 		"mov x8, #135					\n" /* __NR_rt_sigprocmask */
 		"mov x0, %0					\n" /* @how */
 		"mov x1, x10					\n" /* @nset */
-		"add x2, x10, #8				\n" /* @oset */
-		"mov x11, x2					\n"
+		"mov x2, x10					\n" /* @oset */
 		"mov x3, #8					\n" /* @sigsetsize */
 		"svc #0						\n"
-		"ldr x8, [x11]					\n"
 		"brk #0						\n" /* SIGTRAP */
 		".global sigprocmask_blob_size			\n"
 		"sigprocmask_blob_size:				\n"

--- a/arch/x86_64/enter.c
+++ b/arch/x86_64/enter.c
@@ -50,11 +50,9 @@ void __attribute__((used)) container(void)
 		"movq $14, %%rax				\n" /* __NR_rt_sigprocmask */
 		"movq %0, %%rdi					\n" /* @how */
 		"movq %%r15, %%rsi				\n" /* @nset */
-		"addq $8, %%r15					\n"
 		"movq %%r15, %%rdx				\n" /* @oset */
 		"movq $8, %%r10					\n" /* @sigsetsize */
 		"syscall					\n"
-		"movq (%%r15), %%r15				\n" /* *@oset */
 		"int $0x03					\n"
 		".global sigprocmask_blob_size			\n"
 		"sigprocmask_blob_size:				\n"

--- a/memcr.h
+++ b/memcr.h
@@ -90,10 +90,10 @@ struct target_context {
 	unsigned long *src;
 	unsigned long *dst;
 	unsigned long *saved_code;
-	unsigned long saved_sigmask;
 	unsigned long saved_stack[16];
+	uint64_t sigset;
 	int count;
-} __attribute__((packed));
+};
 
 #endif
 


### PR DESCRIPTION
Kernel sigset_t size is 8 bytes so the code now correctly handles peek/poke operation on 32 and 64 bit architectures. Also sigprocmask_blob is simplified as rt_sigprocmask syscall allows nset and oset point to the same address.