### PR TITLE
Handle parasite terminated by SIGKILL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ MCFLAGS = $(CFLAGS) -g
 # parasite CFLAGS
 PCFLAGS = $(CFLAGS)
 
+LDFLAGS = -lpthread
+
 ifeq ("$(origin O)", "command line")
     GCC_O = $(O)
 endif
@@ -115,7 +117,7 @@ $(B)/memcr.o: memcr.c $(B)/parasite-blob.h
 	$(CC) $(MCFLAGS) -I$(B) -c $< -o $@
 
 $(B)/memcr: $(B)/memcr.o $(B)/cpu.o $(B)/enter.o
-	$(CC) $(MCFLAGS) $^ -o $@
+	$(CC) $(MCFLAGS) $^ $(LDFLAGS) -o $@
 
 $(B)/memcr-client.o: memcr-client.c
 	$(CC) $(CFLAGS) -I$(B) -c $< -o $@

--- a/arch/arm/enter.c
+++ b/arch/arm/enter.c
@@ -93,7 +93,7 @@ static void __attribute__((used)) container(void)
 		"bxeq r8					\n" /* bx parasite */
 		"udf #16					\n" /* SIGTRAP */
 		"CLONE_FLAGS:					\n"
-		".word 0x80052f00				\n" /* (CLONE_FILES | CLONE_FS | CLONE_IO | CLONE_SIGHAND | CLONE_SYSVSEM | CLONE_THREAD | CLONE_VM | CLONE_PTRACE) */
+		".word 0x80050f00				\n" /* (CLONE_FILES | CLONE_FS | CLONE_IO | CLONE_SIGHAND | CLONE_SYSVSEM | CLONE_THREAD | CLONE_VM) */
 		".global clone_blob_size			\n"
 		"clone_blob_size:				\n"
 		".int clone_blob_size - clone_blob		\n"

--- a/arch/arm64/enter.c
+++ b/arch/arm64/enter.c
@@ -100,7 +100,7 @@ static void __attribute__((used)) container(void)
 		".global clone_blob_size			\n"
 		"clone_blob_size:				\n"
 		".int clone_blob_size - clone_blob		\n"
-		:: "i" (CLONE_FILES | CLONE_FS | CLONE_IO | CLONE_SIGHAND | CLONE_SYSVSEM | CLONE_THREAD | CLONE_VM | CLONE_PTRACE)
+		:: "i" (CLONE_FILES | CLONE_FS | CLONE_IO | CLONE_SIGHAND | CLONE_SYSVSEM | CLONE_THREAD | CLONE_VM)
 	);
 
 	/* munmap anon area for parasite_blob, expects addr in x10 and len in x11 */

--- a/arch/x86_64/enter.c
+++ b/arch/x86_64/enter.c
@@ -95,7 +95,7 @@ void __attribute__((used)) container(void)
 		".global clone_blob_size			\n"
 		"clone_blob_size:				\n"
 		".int clone_blob_size - clone_blob		\n"
-		:: "i" (CLONE_FILES | CLONE_FS | CLONE_IO | CLONE_SIGHAND | CLONE_SYSVSEM | CLONE_THREAD | CLONE_VM | CLONE_PTRACE));
+		:: "i" (CLONE_FILES | CLONE_FS | CLONE_IO | CLONE_SIGHAND | CLONE_SYSVSEM | CLONE_THREAD | CLONE_VM));
 
 	/* munmaps anon area for parasite_blob, expects mmap address in %r15 and len in %r14 */
 	asm volatile(


### PR DESCRIPTION
To get a notification that parasite was terminated a separate thread is needed that seizes parasite pid, uses wait4() to get the status change and signals it to the main memcr process.