### PR TITLE
Make stdout line buffered

### DIFF
--- a/memcr.c
+++ b/memcr.c
@@ -2035,6 +2035,8 @@ int main(int argc, char *argv[])
 
 	register_signal_handlers();
 
+	setvbuf(stdout, NULL, _IOLBF, 0);
+
 	if (listen_port)
 		ret = service_mode(listen_port);
 	else


### PR DESCRIPTION
When memcr runs as a systemd service stdout is block buffered and logs are shown with a delay. To mitigate that make stdout line buffered as it is done when stdout refers to a terminal.