### PR TITLE
xread() and xwrite() cleanup

### DIFF
--- a/parasite.c
+++ b/parasite.c
@@ -327,7 +327,8 @@ static int cmd_set_pages(int cd)
 static int cmd_end(int cd)
 {
 	finish = 1;
-	return sys_write(cd, &(char){CMD_END}, 1);
+
+	return 0;
 }
 
 static int handle_connection(int cd)


### PR DESCRIPTION
xread() and xwrite() are intended for communication with parasite only so rename them to make it clear. For other purposes _read() and _write() wrappers are provided. Also don't wait for CMD_END response as the parasite could already exit by the time when memcr calls xread() CMD_END. memcr waits for parasite finish in parasite_status_wait().