### PR TITLE
Implement handling of file mapped regions

### DIFF
--- a/memcr.h
+++ b/memcr.h
@@ -74,6 +74,7 @@ struct vm_mprotect {
 
 struct vm_page_addr {
 	void *addr;
+	char tx_page;
 } __attribute__((packed));
 
 struct vm_page {


### PR DESCRIPTION
With -f or --rss-file memcr will attempt to reduce file mapped read only memory regions as well. Pages from these regions are not saved to a page dump file as the memory content will be repopulated from the underlying mapped file on access.

Also minor fixes to parasite code are included.