### PR TITLE
Get memory pages from /proc/pid/mem interface

### DIFF
--- a/memcr.h
+++ b/memcr.h
@@ -85,6 +85,11 @@ struct vm_page {
 #endif
 } __attribute__((packed));
 
+struct vm_region {
+	unsigned long addr;
+	unsigned long length;
+};
+
 struct target_context {
 	pid_t pid;
 	unsigned long *pc;


### PR DESCRIPTION
With -m or --proc-mem memcr will download target pages from /proc/pid/mem interface. This should improve download times as there is less communication with the parasite. Also vm mapped pages are now read as continuous regions where possible (up to 1MB at once). This improves transfer speeds.