### PR TITLE
Transfer vm regions

### DIFF
--- a/memcr.h
+++ b/memcr.h
@@ -25,10 +25,6 @@
 #define PAGE_SIZE 4096
 #endif
 
-#if 0
-#define PAGE_CRC
-#endif
-
 struct parasite_args {
 	char addr[108]; /* abstract or filesystem socket address */
 };
@@ -72,23 +68,17 @@ struct vm_mprotect {
 	unsigned long prot;
 } __attribute__((packed));
 
-struct vm_page_addr {
-	void *addr;
-	char tx_page;
-} __attribute__((packed));
-
-struct vm_page {
-	void *addr;
-	char data[PAGE_SIZE];
-#if defined(PAGE_CRC)
-	uint16_t crc;
-#endif
-} __attribute__((packed));
-
 struct vm_region {
 	unsigned long addr;
-	unsigned long length;
+	unsigned long len;
 };
+
+#define VM_REGION_TX 0x01
+
+struct vm_region_req {
+	struct vm_region vmr;
+	char flags;
+} __attribute__((packed));
 
 struct target_context {
 	pid_t pid;


### PR DESCRIPTION
Currently memory transfer is done page by page which works correctly but is not optimal. To improve transfer times implement transfer of vm regions that are page aligned and are up to 1MB at a time. Also remove page memcpy in parasite and read/write target memory directly.