### PR TITLE
Send error response in case of wrong PID received

### DIFF
--- a/memcr.c
+++ b/memcr.c
@@ -1940,7 +1940,7 @@ static int handle_connection(int cd)
 
 			if (is_pid_checkpointed(svc_cmd.pid)) {
 				fprintf(stdout, "[i] Process %d is already checkpointed!\n", svc_cmd.pid);
-				send_response_to_client(cd, MEMCR_OK);
+				send_response_to_client(cd, MEMCR_ERROR);
 				break;
 			}
 
@@ -1974,7 +1974,7 @@ static int handle_connection(int cd)
 
 			if (!is_pid_checkpointed(svc_cmd.pid)) {
 				fprintf(stdout, "[i] Process %d is not checkpointed!\n", svc_cmd.pid);
-				send_response_to_client(cd, MEMCR_OK);
+				send_response_to_client(cd, MEMCR_ERROR);
 				break;
 			}
 


### PR DESCRIPTION
Memcr service will send 'MEMCR_ERROR' in case of checkpointing an already checkpointed PID or trying to restore not checkpointed one.