### PR TITLE
Make compression and checksumming optional at compile time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,16 @@ MCFLAGS = $(CFLAGS) -g
 # parasite CFLAGS
 PCFLAGS = $(CFLAGS)
 
-LDFLAGS = -lpthread -lcrypto
+LDFLAGS = -lpthread
 
-ifeq ($(MEMCR_DUMP_COMPRESSION_LZ4), 1)
-    MCFLAGS += -DDUMP_COMPRESSION_LZ4
+ifeq ($(COMPRESS_LZ4), 1)
+    MCFLAGS += -DCOMPRESS_LZ4
     LDFLAGS += -llz4
+endif
+
+ifeq ($(CHECKSUM_MD5), 1)
+    MCFLAGS += -DCHECKSUM_MD5
+    LDFLAGS += -lcrypto
 endif
 
 ifeq ("$(origin O)", "command line")

--- a/memcr.bb
+++ b/memcr.bb
@@ -1,7 +1,10 @@
 SUMMARY = "memory checkpoint and restore"
 HOMEPAGE = "https://github.com/LibertyGlobal/memcr"
 SECTION = "console/tools"
-DEPENDS = "util-linux-native"
+DEPENDS = "util-linux-native openssl lz4"
+RDEPENDS_${PN} = "libcrypto lz4"
+
+INSANE_SKIP:${PN} += "ldflags"
 
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=0ba16794955006770904e8293abcbee5"
@@ -14,7 +17,7 @@ PV = "git${SRCPV}"
 S = "${WORKDIR}/git"
 
 do_compile () {
-	oe_runmake
+	oe_runmake COMPRESS_LZ4=1 CHECKSUM_MD5=1
 }
 
 do_install () {


### PR DESCRIPTION
Both compression and checksumming rely on external libraries so these features are made optional at compile time. This is how you enable both of them:

$ make COMPRESS_LZ4=1 CHECKSUM_MD5=1

Once compiled in compression can be enabled with -z or --compress.