### PR TITLE
Fix lseek() offset on /proc/pid/mem with 64 bit kernel and 32 bit use…

### DIFF
--- a/memcr.c
+++ b/memcr.c
@@ -17,6 +17,7 @@
  */
 
 #define _GNU_SOURCE
+#define _FILE_OFFSET_BITS 64
 
 #include <stdio.h>
 #include <sys/types.h>


### PR DESCRIPTION
…rspace