### PR TITLE
Continue read from sock on EINTR error

### DIFF
--- a/memcr.c
+++ b/memcr.c
@@ -689,6 +689,8 @@ static int __read(int fd, void *buf, size_t count, int (*check_peer_ok)(void), i
 					continue;
 
 				break;
+			} else if (errno == EINTR) {
+				continue;
 			}
 
 			if (silent == FALSE)


### PR DESCRIPTION

Otherwise, If timeout is used and one of workers killed,  reading on another worker socket will fail with
__read() failed: Interrupted system call