### PR TITLE
Restore retry

### DIFF
--- a/libencrypt.c
+++ b/libencrypt.c
@@ -100,8 +100,10 @@ int lib__read(int fd, void *buf, size_t count)
 
 	dbg("%s(%d, %p, %d)\n", __func__, fd, buf, (int)count);
 
-	if (!cipher)
+	if (!cipher) {
+		err("cipher not initialized\n");
 		return read(fd, buf, count);
+	}
 
 	if (!ctx) {
 		err("invalid cipher ctx\n");
@@ -165,8 +167,10 @@ int lib__write(int fd, const void *buf, size_t count)
 
 	dbg("%s(%d, %p, %d)\n", __func__, fd, buf, (int)count);
 
-	if (!cipher)
+	if (!cipher) {
+		err("cipher not initialized\n");
 		return write(fd, buf, count);
+	}
 
 	if (!ctx) {
 		err("invalid cipher ctx\n");


### PR DESCRIPTION
Rretry the restore up to 3 times.

Also, the vm_region struct isn’t dumped - it stays in the memcr worker process memory. That is to avoid potential corruption. Since dumps are fully tied to the running memcr instance anyway, there is no real need to include it.
Downside: each memcr process uses a bit more memory, up to around 200 KB more.